### PR TITLE
T/10: Minor Alignment package refactor

### DIFF
--- a/src/alignmentcommand.js
+++ b/src/alignmentcommand.js
@@ -8,7 +8,9 @@
  */
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
+
 import first from '@ckeditor/ckeditor5-utils/src/first';
+import upperFirst from '@ckeditor/ckeditor5-utils/src/lib/lodash/upperFirst';
 
 /**
  * The alignment command plugin.
@@ -124,6 +126,17 @@ export default class AlignmentCommand extends Command {
 		// Command's value will be set when commands type is matched in selection or the selection is default one.
 		return selectionAlignment ? selectionAlignment === this.type : this._isDefault;
 	}
+}
+
+/**
+ * Helper function that returns command name for given style. May produce unknown commands if passed style is not
+ * in {@link module:alignment/alignmentediting~AlignmentEditing.supportedStyles}.
+ *
+ * @param {String} style
+ * @returns {String}
+ */
+export function commandNameFromStyle( style ) {
+	return `align${ upperFirst( style ) }`;
 }
 
 // Removes alignment attribute from blocks.

--- a/src/alignmentediting.js
+++ b/src/alignmentediting.js
@@ -9,12 +9,10 @@
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 
-import AlignmentCommand from './alignmentcommand';
-
 import buildViewConverter from '@ckeditor/ckeditor5-engine/src/conversion/buildviewconverter';
 import { eventNameToConsumableType } from '@ckeditor/ckeditor5-engine/src/conversion/model-to-view-converters';
 
-import upperFirst from '@ckeditor/ckeditor5-utils/src/lib/lodash/upperFirst';
+import AlignmentCommand, { commandNameFromStyle } from './alignmentcommand';
 
 /**
  * @extends module:core/plugin~Plugin
@@ -31,6 +29,7 @@ export default class AlignmentEditing extends Plugin {
 
 	/**
 	 * List of supported alignment styles:
+	 *
 	 * - left
 	 * - right
 	 * - center
@@ -80,7 +79,7 @@ export default class AlignmentEditing extends Plugin {
 		enabledStyles
 			.filter( isSupported )
 			.forEach( style => {
-				editor.commands.add( AlignmentEditing.commandName( style ), new AlignmentCommand( editor, style, isDefault( style ) ) );
+				editor.commands.add( commandNameFromStyle( style ), new AlignmentCommand( editor, style, isDefault( style ) ) );
 			} );
 	}
 
@@ -94,17 +93,6 @@ export default class AlignmentEditing extends Plugin {
 		if ( schema.hasItem( 'caption' ) ) {
 			schema.disallow( { name: 'caption', attributes: 'alignment' } );
 		}
-	}
-
-	/**
-	 * Helper function that returns command name for given style. May produce unknown commands if passed style is not
-	 * in {@link module:alignment/alignmentediting~AlignmentEditing.supportedStyles}.
-	 *
-	 * @param {String} style
-	 * @returns {String}
-	 */
-	static commandName( style ) {
-		return `align${ upperFirst( style ) }`;
 	}
 }
 
@@ -135,8 +123,8 @@ function convertStyle() {
 }
 
 // Check whether alignment is default one.
-// @protected
-export function isDefault( textAlign ) {
+// @private
+function isDefault( textAlign ) {
 	// Right now only RTL is supported so 'left' value is always default one.
 	return textAlign === 'left';
 }

--- a/src/alignmentediting.js
+++ b/src/alignmentediting.js
@@ -30,10 +30,10 @@ export default class AlignmentEditing extends Plugin {
 	/**
 	 * List of supported alignment styles:
 	 *
-	 * - left
-	 * - right
-	 * - center
-	 * - justify
+	 * * `'left'`,
+	 * * `'right'`,
+	 * * `'center'`,
+	 * * `'justify'`
 	 *
 	 * @static
 	 * @readonly

--- a/src/alignmentui.js
+++ b/src/alignmentui.js
@@ -42,10 +42,10 @@ export default class AlignmentUI extends Plugin {
 	 * The following localized titles corresponding with
 	 * {@link module:alignment/alignmentediting~AlignmentEditingConfig#styles} are available:
 	 *
-	 * * `'Left'`,
-	 * * `'Right'`,
-	 * * `'Center'`,
-	 * * `'Justify'`
+	 * * `'left'`,
+	 * * `'right'`,
+	 * * `'center'`,
+	 * * `'justify'`
 	 *
 	 * @readonly
 	 * @type {Object.<String,String>}

--- a/src/alignmentui.js
+++ b/src/alignmentui.js
@@ -62,13 +62,6 @@ export default class AlignmentUI extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	static get requires() {
-		return [ AlignmentEditing ];
-	}
-
-	/**
-	 * @inheritDoc
-	 */
 	static get pluginName() {
 		return 'AlignmentUI';
 	}

--- a/src/alignmentui.js
+++ b/src/alignmentui.js
@@ -10,14 +10,16 @@
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 
 import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
+import Model from '@ckeditor/ckeditor5-ui/src/model';
+import createButtonDropdown from '@ckeditor/ckeditor5-ui/src/dropdown/button/createbuttondropdown';
+
+import { commandNameFromStyle } from './alignmentcommand';
+import { isSupported } from './alignmentediting';
 
 import alignLeftIcon from '../theme/icons/align-left.svg';
 import alignRightIcon from '../theme/icons/align-right.svg';
 import alignCenterIcon from '../theme/icons/align-center.svg';
 import alignJustifyIcon from '../theme/icons/align-justify.svg';
-import AlignmentEditing, { isSupported } from './alignmentediting';
-import createButtonDropdown from '@ckeditor/ckeditor5-ui/src/dropdown/button/createbuttondropdown';
-import Model from '../../ckeditor5-ui/src/model';
 
 const icons = new Map( [
 	[ 'left', alignLeftIcon ],
@@ -81,7 +83,7 @@ export default class AlignmentUI extends Plugin {
 
 		componentFactory.add( 'alignmentDropdown', locale => {
 			const buttons = styles.map( style => {
-				return componentFactory.create( AlignmentEditing.commandName( style ) );
+				return componentFactory.create( commandNameFromStyle( style ) );
 			} );
 
 			const model = new Model( {
@@ -94,9 +96,7 @@ export default class AlignmentUI extends Plugin {
 				buttons
 			} );
 
-			const dropdown = createButtonDropdown( model, locale );
-
-			return dropdown;
+			return createButtonDropdown( model, locale );
 		} );
 	}
 
@@ -109,7 +109,7 @@ export default class AlignmentUI extends Plugin {
 	_addButton( style ) {
 		const editor = this.editor;
 
-		const commandName = AlignmentEditing.commandName( style );
+		const commandName = commandNameFromStyle( style );
 		const command = editor.commands.get( commandName );
 
 		editor.ui.componentFactory.add( commandName, locale => {

--- a/tests/alignmentui.js
+++ b/tests/alignmentui.js
@@ -34,10 +34,6 @@ describe( 'Alignment', () => {
 		return editor.destroy();
 	} );
 
-	it( 'requires AlignmentEditing', () => {
-		expect( AlignmentUI.requires ).to.deep.equal( [ AlignmentEditing ] );
-	} );
-
 	describe( 'localizedStylesTitles()', () => {
 		it( 'should return localized titles of styles', () => {
 			const editorMock = { t: str => str };


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Refactor Alignment feature split. Closes ckeditor/ckeditor5#2119.

---

### Additional information

The minor things were cleaned up but one thing brings some concerns. Alignment has around 3 helper methods that are used in `AlignmentEditing` and in `AlignmentUI` as well. Those are small methods but it make sense to have them in one place to have them unified.

Right now those methods are placed along some class (like in `AlignemntEditing` or `AlignmentCommand`). I don't know it importing `Class` file to import helper methods is OK in CKE 5 code base?
