### PR TITLE
eventNameToConsumableType is no longer needed nor available

### DIFF
--- a/src/alignmentediting.js
+++ b/src/alignmentediting.js
@@ -7,12 +7,10 @@
  * @module alignment/alignmentediting
  */
 
-import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
-
-import buildViewConverter from '@ckeditor/ckeditor5-engine/src/conversion/buildviewconverter';
-import { eventNameToConsumableType } from '@ckeditor/ckeditor5-engine/src/conversion/model-to-view-converters';
-
 import AlignmentCommand, { commandNameFromStyle } from './alignmentcommand';
+
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import buildViewConverter from '@ckeditor/ckeditor5-engine/src/conversion/buildviewconverter';
 
 /**
  * @extends module:core/plugin~Plugin
@@ -98,7 +96,7 @@ export function isSupported( style ) {
 // @private
 function convertStyle() {
 	return ( evt, data, consumable, conversionApi ) => {
-		if ( !consumable.consume( data.item, eventNameToConsumableType( evt.name ) ) ) {
+		if ( !consumable.consume( data.item, evt.name ) ) {
 			return;
 		}
 

--- a/tests/alignmentediting.js
+++ b/tests/alignmentediting.js
@@ -10,7 +10,6 @@ import ListEngine from '@ckeditor/ckeditor5-list/src/listengine';
 import HeadingEngine from '@ckeditor/ckeditor5-heading/src/headingengine';
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
-import { eventNameToConsumableType } from '@ckeditor/ckeditor5-engine/src/conversion/model-to-view-converters';
 
 import AlignmentCommand from '../src/alignmentcommand';
 
@@ -227,6 +226,6 @@ describe( 'AlignmentEditing', () => {
 
 function blockDefaultConversion( dispatcher ) {
 	dispatcher.on( 'attribute:alignment', ( evt, data, consumable ) => {
-		consumable.consume( data.item, eventNameToConsumableType( evt.name ) );
+		consumable.consume( data.item, evt.name );
 	}, { 'priority': 'high' } );
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Changed: `eventNameToConsumableType` is no longer needed nor available.

---

### Additional information

This PR is related to https://github.com/ckeditor/ckeditor5-engine/pull/1241