### PR TITLE
t/ckeditor5/1348: Used the getViewportTopOffsetConfig helper in the code snippets.

### DIFF
--- a/docs/_snippets/features/custom-text-alignment-options.js
+++ b/docs/_snippets/features/custom-text-alignment-options.js
@@ -13,7 +13,7 @@ ClassicEditor
 			items: [
 				'heading', '|', 'bulletedList', 'numberedList', 'alignment', 'undo', 'redo'
 			],
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		},
 		alignment: {
 			options: [ 'left', 'right' ]

--- a/docs/_snippets/features/custom-text-alignment-toolbar.js
+++ b/docs/_snippets/features/custom-text-alignment-toolbar.js
@@ -13,7 +13,7 @@ ClassicEditor
 			items: [
 				'heading', '|', 'alignment:left', 'alignment:right', 'alignment:center', 'alignment:justify'
 			],
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		},
 		cloudServices: CS_CONFIG
 	} )

--- a/docs/_snippets/features/text-alignment.js
+++ b/docs/_snippets/features/text-alignment.js
@@ -13,7 +13,7 @@ ClassicEditor
 			items: [
 				'heading', '|', 'bulletedList', 'numberedList', 'alignment', 'undo', 'redo'
 			],
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		},
 		cloudServices: CS_CONFIG
 	} )


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Used the `getViewportTopOffsetConfig` helper in the code snippets to make sure the toolbar top offset is correct regardless of the page layout (see ckeditor/ckeditor5#1348).

---

### Additional information

This PR is a piece of the https://github.com/ckeditor/ckeditor5/pull/1360 constellation.
