### PR TITLE
Marked alignment attribute with the AttributeProperties#isFormatting property

### DIFF
--- a/src/alignmentediting.js
+++ b/src/alignmentediting.js
@@ -41,6 +41,7 @@ export default class AlignmentEditing extends Plugin {
 
 		// Allow alignment attribute on all blocks.
 		schema.extend( '$block', { allowAttributes: 'alignment' } );
+		editor.model.schema.setAttributeProperties( 'alignment', { isFormatting: true } );
 
 		const definition = _buildDefinition( enabledOptions.filter( option => !isDefault( option ) ) );
 

--- a/tests/alignmentediting.js
+++ b/tests/alignmentediting.js
@@ -39,6 +39,12 @@ describe( 'AlignmentEditing', () => {
 		expect( model.schema.checkAttribute( [ '$root', '$block' ], 'alignment' ) ).to.be.true;
 	} );
 
+	it( 'its attribute is marked with a formatting property', () => {
+		expect( model.schema.getAttributeProperties( 'alignment' ) ).to.deep.equal( {
+			isFormatting: true
+		} );
+	} );
+
 	describe( 'integration', () => {
 		beforeEach( () => {
 			return VirtualTestEditor


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Marked alignment as a formatting attribute using the `AttributeProperties#isFormatting` property. Closes ckeditor/ckeditor5#1664.

---

### Additional information

There are 2 more pull requests related with this in respective repositories.

All The PRs are referenced in ckeditor/ckeditor5#1664.