### PR TITLE
Mark alignment attribute with 'copyOnEnter' property

### DIFF
--- a/src/alignmentediting.js
+++ b/src/alignmentediting.js
@@ -41,7 +41,10 @@ export default class AlignmentEditing extends Plugin {
 
 		// Allow alignment attribute on all blocks.
 		schema.extend( '$block', { allowAttributes: 'alignment' } );
-		editor.model.schema.setAttributeProperties( 'alignment', { isFormatting: true } );
+		editor.model.schema.setAttributeProperties( 'alignment', {
+			isFormatting: true,
+			copyOnEnter: true
+		} );
 
 		const definition = _buildDefinition( enabledOptions.filter( option => !isDefault( option ) ) );
 

--- a/tests/alignmentediting.js
+++ b/tests/alignmentediting.js
@@ -40,8 +40,14 @@ describe( 'AlignmentEditing', () => {
 	} );
 
 	it( 'its attribute is marked with a formatting property', () => {
-		expect( model.schema.getAttributeProperties( 'alignment' ) ).to.deep.equal( {
+		expect( model.schema.getAttributeProperties( 'alignment' ) ).to.include( {
 			isFormatting: true
+		} );
+	} );
+
+	it( 'its attribute is marked with a copOnEnter property', () => {
+		expect( model.schema.getAttributeProperties( 'alignment' ) ).to.include( {
+			copyOnEnter: true
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Mark alignment attribute with 'copyOnEnter' property.

---

### Additional information

* Requires: ckeditor/ckeditor5-enter#63