### PR TITLE
T/ckeditor5/1151: Integrated the text alignment feature with different editor content directions

### DIFF
--- a/docs/features/text-alignment.md
+++ b/docs/features/text-alignment.md
@@ -16,7 +16,7 @@ The {@link module:alignment/alignment~Alignment} feature enables support for tex
 It is possible to configure which alignment options are available in the editor by setting the {@link module:alignment/alignment~AlignmentConfig#options `alignment.options`} configuration option. You can choose from `'left'`, `'right'`, `'center'` and `'justify'`.
 
 <info-box>
-	Note that `'left'` or `'right'` should always be included for <abbr title="left–to–right">LTR</abbr> and <abbr title="right-to-left">RTL</abbr> content, respectively. Learn more about {@link features/ui-language#setting-the-language-of-the-content configuring language of the editor content}.
+	Note that the `'left'` option should always be included for the <abbr title="left–to–right">LTR</abbr> content. Similarly, the `'right'` option should always be included for the <abbr title="right-to-left">RTL</abbr> content. Learn more about {@link features/ui-language#setting-the-language-of-the-content configuring language of the editor content}.
 </info-box>
 
 For example, the following editor will support only two alignment options: to the left and to the right:

--- a/docs/features/text-alignment.md
+++ b/docs/features/text-alignment.md
@@ -13,7 +13,11 @@ The {@link module:alignment/alignment~Alignment} feature enables support for tex
 
 ## Configuring alignment options
 
-It is possible to configure which alignment options are available in the editor by setting the {@link module:alignment/alignment~AlignmentConfig#options `alignment.options`} configuration option. You can choose from `'left'`, `'right'`, `'center'` and `'justify'`;  note that `'left'` should always be included.
+It is possible to configure which alignment options are available in the editor by setting the {@link module:alignment/alignment~AlignmentConfig#options `alignment.options`} configuration option. You can choose from `'left'`, `'right'`, `'center'` and `'justify'`.
+
+<info-box>
+	Note that `'left'` or `'right'` should always be included for <abbr title="left–to–right">LTR</abbr> and <abbr title="right-to-left">RTL</abbr> content, respectively. Learn more about {@link features/ui-language#setting-the-language-of-the-content configuring language of the editor content}.
+</info-box>
 
 For example, the following editor will support only two alignment options: to the left and to the right:
 

--- a/src/alignment.js
+++ b/src/alignment.js
@@ -69,8 +69,9 @@ export default class Alignment extends Plugin {
  *
  * The available options are: `'left'`, `'right'`, `'center'` and `'justify'`. Other values are ignored.
  *
- * **Note:** It is recommended to always use `'left'` as it is the default value which the user should
- * normally be able to choose.
+ * **Note:** It is recommended to always use `'left'` or `'right'` as these are default values which the user should
+ * normally be able to choose depending on the
+ * {@glink features/ui-language#setting-the-language-of-the-content language of the editor content}.
  *
  *		ClassicEditor
  *			.create( editorElement, {

--- a/src/alignmentcommand.js
+++ b/src/alignmentcommand.js
@@ -24,6 +24,8 @@ export default class AlignmentCommand extends Command {
 	 * @inheritDoc
 	 */
 	refresh() {
+		const editor = this.editor;
+		const locale = editor.locale;
 		const firstBlock = first( this.editor.model.document.selection.getSelectedBlocks() );
 
 		// As first check whether to enable or disable the command as the value will always be false if the command cannot be enabled.
@@ -36,7 +38,11 @@ export default class AlignmentCommand extends Command {
 		 * @readonly
 		 * @member {String} #value
 		 */
-		this.value = ( this.isEnabled && firstBlock.hasAttribute( 'alignment' ) ) ? firstBlock.getAttribute( 'alignment' ) : 'left';
+		if ( this.isEnabled && firstBlock.hasAttribute( 'alignment' ) ) {
+			this.value = firstBlock.getAttribute( 'alignment' );
+		} else {
+			this.value = locale.contentLanguageDirection === 'rtl' ? 'right' : 'left';
+		}
 	}
 
 	/**
@@ -50,6 +56,7 @@ export default class AlignmentCommand extends Command {
 	 */
 	execute( options = {} ) {
 		const editor = this.editor;
+		const locale = editor.locale;
 		const model = editor.model;
 		const doc = model.document;
 
@@ -64,7 +71,7 @@ export default class AlignmentCommand extends Command {
 			// - default (should not be stored in model as it will bloat model data)
 			// - equal to currently set
 			// - or no value is passed - denotes default alignment.
-			const removeAlignment = isDefault( value ) || currentAlignment === value || !value;
+			const removeAlignment = isDefault( value, locale ) || currentAlignment === value || !value;
 
 			if ( removeAlignment ) {
 				removeAlignmentFromSelection( blocks, writer );

--- a/src/alignmentediting.js
+++ b/src/alignmentediting.js
@@ -34,6 +34,7 @@ export default class AlignmentEditing extends Plugin {
 	 */
 	init() {
 		const editor = this.editor;
+		const locale = editor.locale;
 		const schema = editor.model.schema;
 
 		// Filter out unsupported options.
@@ -43,7 +44,7 @@ export default class AlignmentEditing extends Plugin {
 		schema.extend( '$block', { allowAttributes: 'alignment' } );
 		editor.model.schema.setAttributeProperties( 'alignment', { isFormatting: true } );
 
-		const definition = _buildDefinition( enabledOptions.filter( option => !isDefault( option ) ) );
+		const definition = _buildDefinition( enabledOptions.filter( option => !isDefault( option, locale ) ) );
 
 		editor.conversion.attributeToAttribute( definition );
 

--- a/src/alignmentui.js
+++ b/src/alignmentui.js
@@ -100,8 +100,8 @@ export default class AlignmentUI extends Plugin {
 				}
 			} );
 
-			// The default icon is align left as we do not support RTL yet (see #3).
-			const defaultIcon = alignLeftIcon;
+			// The default icon depends on the direction of the content.
+			const defaultIcon = locale.contentLanguageDirection === 'rtl' ? alignRightIcon : alignLeftIcon;
 
 			// Change icon to reflect current selection's alignment.
 			dropdownView.buttonView.bind( 'icon' ).toMany( buttons, 'isOn', ( ...areActive ) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,12 +28,19 @@ export function isSupported( option ) {
 }
 
 /**
- * Checks whether alignment is the default one.
+ * Checks whether alignment is the default one considering the direction
+ * of the editor content.
  *
  * @param {String} alignment The name of the alignment to check.
+ * @param {module:utils/locale~Locale} locale The {@link module:core/editor/editor~Editor#locale} instance.
  * @returns {Boolean}
  */
-export function isDefault( alignment ) {
+export function isDefault( alignment, locale ) {
 	// Right now only LTR is supported so the 'left' value is always the default one.
-	return alignment === 'left';
+
+	if ( locale.contentLanguageDirection == 'rtl' ) {
+		return alignment === 'right';
+	} else {
+		return alignment === 'left';
+	}
 }

--- a/tests/alignmentcommand.js
+++ b/tests/alignmentcommand.js
@@ -52,7 +52,9 @@ describe( 'AlignmentCommand', () => {
 
 		it( 'is set to default alignment when selection is in block with default alignment (RTL content)', () => {
 			return ModelTestEditor.create( {
-				contentLanguage: 'ar'
+				language: {
+					content: 'ar'
+				}
 			} ).then( newEditor => {
 				model = newEditor.model;
 				command = new AlignmentCommand( newEditor );
@@ -105,7 +107,9 @@ describe( 'AlignmentCommand', () => {
 
 			it( 'should remove alignment from single block element if already has one (RTL content)', () => {
 				return ModelTestEditor.create( {
-					contentLanguage: 'ar'
+					language: {
+						content: 'ar'
+					}
 				} ).then( newEditor => {
 					model = newEditor.model;
 					command = new AlignmentCommand( newEditor );

--- a/tests/alignmentcommand.js
+++ b/tests/alignmentcommand.js
@@ -44,10 +44,30 @@ describe( 'AlignmentCommand', () => {
 			expect( command ).to.have.property( 'value', 'center' );
 		} );
 
-		it( 'is set to default alignment when selection is in block with default alignment', () => {
+		it( 'is set to default alignment when selection is in block with default alignment (LTR content)', () => {
 			setModelData( model, '<paragraph>x[]x</paragraph>' );
 
 			expect( command ).to.have.property( 'value', 'left' );
+		} );
+
+		it( 'is set to default alignment when selection is in block with default alignment (RTL content)', () => {
+			return ModelTestEditor.create( {
+				contentLanguage: 'ar'
+			} ).then( newEditor => {
+				model = newEditor.model;
+				command = new AlignmentCommand( newEditor );
+				newEditor.commands.add( 'alignment', command );
+
+				model.schema.register( 'paragraph', { inheritAllFrom: '$block' } );
+				model.schema.register( 'div', { inheritAllFrom: '$block' } );
+				model.schema.extend( 'paragraph', { allowAttributes: 'alignment' } );
+
+				setModelData( model, '<paragraph>x[]x</paragraph>' );
+
+				expect( command ).to.have.property( 'value', 'right' );
+
+				return newEditor.destroy();
+			} );
 		} );
 	} );
 
@@ -75,12 +95,34 @@ describe( 'AlignmentCommand', () => {
 				expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">x[]x</paragraph>' );
 			} );
 
-			it( 'should remove alignment from single block element if already has one', () => {
+			it( 'should remove alignment from single block element if already has one (LTR content)', () => {
 				setModelData( model, '<paragraph alignment="center">x[]x</paragraph>' );
 
 				editor.execute( 'alignment', { value: 'left' } );
 
 				expect( getModelData( model ) ).to.equal( '<paragraph>x[]x</paragraph>' );
+			} );
+
+			it( 'should remove alignment from single block element if already has one (RTL content)', () => {
+				return ModelTestEditor.create( {
+					contentLanguage: 'ar'
+				} ).then( newEditor => {
+					model = newEditor.model;
+					command = new AlignmentCommand( newEditor );
+					newEditor.commands.add( 'alignment', command );
+
+					model.schema.register( 'paragraph', { inheritAllFrom: '$block' } );
+					model.schema.register( 'div', { inheritAllFrom: '$block' } );
+					model.schema.extend( 'paragraph', { allowAttributes: 'alignment' } );
+
+					setModelData( model, '<paragraph alignment="center">x[]x</paragraph>' );
+
+					newEditor.execute( 'alignment', { value: 'right' } );
+
+					expect( getModelData( model ) ).to.equal( '<paragraph>x[]x</paragraph>' );
+
+					return newEditor.destroy();
+				} );
 			} );
 
 			it( 'adds alignment to all selected blocks', () => {

--- a/tests/alignmentediting.js
+++ b/tests/alignmentediting.js
@@ -98,7 +98,9 @@ describe( 'AlignmentEditing', () => {
 			it( 'adds converters to the data pipeline', () => {
 				return VirtualTestEditor
 					.create( {
-						contentLanguage: 'ar',
+						language: {
+							content: 'ar'
+						},
 						plugins: [ AlignmentEditing, Paragraph ]
 					} )
 					.then( newEditor => {
@@ -117,7 +119,9 @@ describe( 'AlignmentEditing', () => {
 			it( 'adds a converter to the view pipeline', () => {
 				return VirtualTestEditor
 					.create( {
-						contentLanguage: 'ar',
+						language: {
+							content: 'ar'
+						},
 						plugins: [ AlignmentEditing, Paragraph ]
 					} )
 					.then( newEditor => {
@@ -191,7 +195,9 @@ describe( 'AlignmentEditing', () => {
 			it( 'adds converters to the data pipeline', () => {
 				return VirtualTestEditor
 					.create( {
-						contentLanguage: 'ar',
+						language: {
+							content: 'ar'
+						},
 						plugins: [ AlignmentEditing, Paragraph ]
 					} )
 					.then( newEditor => {
@@ -210,7 +216,9 @@ describe( 'AlignmentEditing', () => {
 			it( 'adds a converter to the view pipeline', () => {
 				return VirtualTestEditor
 					.create( {
-						contentLanguage: 'ar',
+						language: {
+							content: 'ar'
+						},
 						plugins: [ AlignmentEditing, Paragraph ]
 					} )
 					.then( newEditor => {

--- a/tests/alignmentediting.js
+++ b/tests/alignmentediting.js
@@ -77,13 +77,58 @@ describe( 'AlignmentEditing', () => {
 	} );
 
 	describe( 'left alignment', () => {
-		it( 'adds converters to the data pipeline', () => {
-			const data = '<p style="text-align:left;">x</p>';
+		describe( 'LTR content', () => {
+			it( 'adds converters to the data pipeline', () => {
+				const data = '<p style="text-align:left;">x</p>';
 
-			editor.setData( data );
+				editor.setData( data );
 
-			expect( getModelData( model ) ).to.equal( '<paragraph>[]x</paragraph>' );
-			expect( editor.getData() ).to.equal( '<p>x</p>' );
+				expect( getModelData( model ) ).to.equal( '<paragraph>[]x</paragraph>' );
+				expect( editor.getData() ).to.equal( '<p>x</p>' );
+			} );
+
+			it( 'adds a converter to the view pipeline', () => {
+				setModelData( model, '<paragraph alignment="left">[]x</paragraph>' );
+
+				expect( editor.getData() ).to.equal( '<p>x</p>' );
+			} );
+		} );
+
+		describe( 'RTL content', () => {
+			it( 'adds converters to the data pipeline', () => {
+				return VirtualTestEditor
+					.create( {
+						contentLanguage: 'ar',
+						plugins: [ AlignmentEditing, Paragraph ]
+					} )
+					.then( newEditor => {
+						const model = newEditor.model;
+						const data = '<p style="text-align:left;">x</p>';
+
+						newEditor.setData( data );
+
+						expect( getModelData( model ) ).to.equal( '<paragraph alignment="left">[]x</paragraph>' );
+						expect( newEditor.getData() ).to.equal( '<p style="text-align:left;">x</p>' );
+
+						return newEditor.destroy();
+					} );
+			} );
+
+			it( 'adds a converter to the view pipeline', () => {
+				return VirtualTestEditor
+					.create( {
+						contentLanguage: 'ar',
+						plugins: [ AlignmentEditing, Paragraph ]
+					} )
+					.then( newEditor => {
+						const model = newEditor.model;
+
+						setModelData( model, '<paragraph alignment="left">[]x</paragraph>' );
+						expect( newEditor.getData() ).to.equal( '<p style="text-align:left;">x</p>' );
+
+						return newEditor.destroy();
+					} );
+			} );
 		} );
 
 		it( 'adds a converter to the view pipeline for removing attribute', () => {
@@ -125,19 +170,58 @@ describe( 'AlignmentEditing', () => {
 	} );
 
 	describe( 'right alignment', () => {
-		it( 'adds converters to the data pipeline', () => {
-			const data = '<p style="text-align:right;">x</p>';
+		describe( 'LTR content', () => {
+			it( 'adds converters to the data pipeline', () => {
+				const data = '<p style="text-align:right;">x</p>';
 
-			editor.setData( data );
+				editor.setData( data );
 
-			expect( getModelData( model ) ).to.equal( '<paragraph alignment="right">[]x</paragraph>' );
-			expect( editor.getData() ).to.equal( data );
+				expect( getModelData( model ) ).to.equal( '<paragraph alignment="right">[]x</paragraph>' );
+				expect( editor.getData() ).to.equal( data );
+			} );
+
+			it( 'adds a converter to the view pipeline', () => {
+				setModelData( model, '<paragraph alignment="right">[]x</paragraph>' );
+
+				expect( editor.getData() ).to.equal( '<p style="text-align:right;">x</p>' );
+			} );
 		} );
 
-		it( 'adds a converter to the view pipeline', () => {
-			setModelData( model, '<paragraph alignment="right">[]x</paragraph>' );
+		describe( 'RTL content', () => {
+			it( 'adds converters to the data pipeline', () => {
+				return VirtualTestEditor
+					.create( {
+						contentLanguage: 'ar',
+						plugins: [ AlignmentEditing, Paragraph ]
+					} )
+					.then( newEditor => {
+						const model = newEditor.model;
+						const data = '<p style="text-align:right;">x</p>';
 
-			expect( editor.getData() ).to.equal( '<p style="text-align:right;">x</p>' );
+						newEditor.setData( data );
+
+						expect( getModelData( model ) ).to.equal( '<paragraph>[]x</paragraph>' );
+						expect( newEditor.getData() ).to.equal( '<p>x</p>' );
+
+						return newEditor.destroy();
+					} );
+			} );
+
+			it( 'adds a converter to the view pipeline', () => {
+				return VirtualTestEditor
+					.create( {
+						contentLanguage: 'ar',
+						plugins: [ AlignmentEditing, Paragraph ]
+					} )
+					.then( newEditor => {
+						const model = newEditor.model;
+
+						setModelData( model, '<paragraph alignment="right">[]x</paragraph>' );
+						expect( newEditor.getData() ).to.equal( '<p>x</p>' );
+
+						return newEditor.destroy();
+					} );
+			} );
 		} );
 	} );
 

--- a/tests/alignmentui.js
+++ b/tests/alignmentui.js
@@ -295,7 +295,9 @@ describe( 'Alignment UI', () => {
 
 				return ClassicTestEditor
 					.create( element, {
-						contentLanguage: 'ar',
+						language: {
+							content: 'ar'
+						},
 						plugins: [ AlignmentEditing, AlignmentUI ],
 						alignment: { options: [ 'center', 'justify' ] }
 					} )

--- a/tests/alignmentui.js
+++ b/tests/alignmentui.js
@@ -9,6 +9,7 @@ import AlignmentEditing from '../src/alignmentediting';
 import AlignmentUI from '../src/alignmentui';
 
 import alignLeftIcon from '../theme/icons/align-left.svg';
+import alignRightIcon from '../theme/icons/align-right.svg';
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 
@@ -284,8 +285,27 @@ describe( 'Alignment UI', () => {
 				expect( items.includes( 'Justify' ) ).to.be.true;
 			} );
 
-			it( 'should have default icon set', () => {
+			it( 'should have default icon set (LTR content)', () => {
 				expect( dropdown.buttonView.icon ).to.equal( alignLeftIcon );
+			} );
+
+			it( 'should have default icon set (RTL content)', () => {
+				const element = document.createElement( 'div' );
+				document.body.appendChild( element );
+
+				return ClassicTestEditor
+					.create( element, {
+						contentLanguage: 'ar',
+						plugins: [ AlignmentEditing, AlignmentUI ],
+						alignment: { options: [ 'center', 'justify' ] }
+					} )
+					.then( newEditor => {
+						dropdown = newEditor.ui.componentFactory.create( 'alignment' );
+
+						expect( dropdown.buttonView.icon ).to.equal( alignRightIcon );
+
+						return newEditor.destroy();
+					} );
 			} );
 
 			it( 'should change icon to active alignment', () => {

--- a/tests/manual/rtl.html
+++ b/tests/manual/rtl.html
@@ -1,0 +1,9 @@
+<div id="editor">
+	<p>This should be aligned to the right</p>
+
+	<p style="text-align:left">This should be aligned to the left.</p>
+
+	<p style="text-align:center">This should be centered.</p>
+
+	<p style="text-align:justify">This should be justified but also to the right. This should be justified but also to the right. This should be justified but also to the right.</p>
+</div>

--- a/tests/manual/rtl.js
+++ b/tests/manual/rtl.js
@@ -12,7 +12,6 @@ import Alignment from '../../src/alignment';
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		language: 'ar',
-		contentLanguage: 'ar',
 		plugins: [ ArticlePluginSet, Alignment ],
 		toolbar: [
 			'heading', '|', 'alignment', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'

--- a/tests/manual/rtl.js
+++ b/tests/manual/rtl.js
@@ -1,0 +1,26 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+import Alignment from '../../src/alignment';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		language: 'ar',
+		contentLanguage: 'ar',
+		plugins: [ ArticlePluginSet, Alignment ],
+		toolbar: [
+			'heading', '|', 'alignment', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'
+		]
+	} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/tests/manual/rtl.md
+++ b/tests/manual/rtl.md
@@ -1,0 +1,6 @@
+## Text alignment and RTL content
+
+1. The editor should run in RTL mode.
+1. Paragraphs in the content should be aligned according to the text inside.
+1. See the toolbar (dropdown) icon as you travel across the document with your caret. The icon should reflect the alignment (default is **right**).
+1. You should be able to use the dropdown to change the alignment of existing and new text.

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -7,11 +7,26 @@ import { isDefault, isSupported, supportedOptions } from '../src/utils';
 
 describe( 'utils', () => {
 	describe( 'isDefault()', () => {
-		it( 'should return true for "left" alignment only', () => {
-			expect( isDefault( 'left' ) ).to.be.true;
-			expect( isDefault( 'right' ) ).to.be.false;
-			expect( isDefault( 'center' ) ).to.be.false;
-			expect( isDefault( 'justify' ) ).to.be.false;
+		it( 'should return true for "left" alignment only (LTR)', () => {
+			const locale = {
+				contentLanguageDirection: 'ltr'
+			};
+
+			expect( isDefault( 'left', locale ) ).to.be.true;
+			expect( isDefault( 'right', locale ) ).to.be.false;
+			expect( isDefault( 'center', locale ) ).to.be.false;
+			expect( isDefault( 'justify', locale ) ).to.be.false;
+		} );
+
+		it( 'should return true for "right" alignment only (RTL)', () => {
+			const locale = {
+				contentLanguageDirection: 'rtl'
+			};
+
+			expect( isDefault( 'left', locale ) ).to.be.false;
+			expect( isDefault( 'right', locale ) ).to.be.true;
+			expect( isDefault( 'center', locale ) ).to.be.false;
+			expect( isDefault( 'justify', locale ) ).to.be.false;
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Integrated the text alignment feature with different editor content directions (LTR and RTL). See ckeditor/ckeditor5#1151.

---

### Additional information

A piece of https://github.com/ckeditor/ckeditor5/pull/1881.