### PR TITLE
Set UI buttons as toggleable

### DIFF
--- a/src/alignmentui.js
+++ b/src/alignmentui.js
@@ -140,7 +140,8 @@ export default class AlignmentUI extends Plugin {
 			buttonView.set( {
 				label: this.localizedOptionTitles[ option ],
 				icon: icons.get( option ),
-				tooltip: true
+				tooltip: true,
+				isToggleable: true
 			} );
 
 			// Bind button model to command.

--- a/tests/alignmentui.js
+++ b/tests/alignmentui.js
@@ -59,6 +59,7 @@ describe( 'Alignment UI', () => {
 			expect( button ).to.have.property( 'label', 'Align left' );
 			expect( button ).to.have.property( 'icon' );
 			expect( button ).to.have.property( 'tooltip', true );
+			expect( button ).to.have.property( 'isToggleable', true );
 		} );
 
 		it( 'has isOn bound to command\'s value', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Set UI buttons as toggleable.

---

### Additional information

Requires: ckeditor/ckeditor5-ui#517
